### PR TITLE
Fix empty string handling for FixedString() column

### DIFF
--- a/asynch/proto/io.py
+++ b/asynch/proto/io.py
@@ -47,14 +47,12 @@ class BufferedWriter:
             await self.write_bytes(packet)
 
     async def write_fixed_strings(self, data, length):
-        buffer = bytearray(b"\0" * length)
         for item in data:
             if isinstance(item, str):
                 packet = item.encode()
             else:
                 packet = item
-            buffer[: len(packet)] = packet
-            await self.write_bytes(buffer)
+            await self.write_bytes(packet.ljust(length, b"\x00"))
 
     async def close(self):
         if not self.writer:

--- a/tests/test_proto/columns/test_stringcolumn.py
+++ b/tests/test_proto/columns/test_stringcolumn.py
@@ -16,7 +16,11 @@ def test_create_string_column(spec, column_options, expected_column):
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "spec, items, expected_buffer",
-    [("String", ["1"], bytearray(b"\x011")), ("FixedString(2)", ["12", "34"], bytearray(b"1234"))],
+    [
+        ("String", ["1"], bytearray(b"\x011")),
+        ("FixedString(2)", ["12", "34"], bytearray(b"1234")),
+        ("FixedString(2)", ["12", "", "34", "5"], bytearray(b"12\x00\x00345\x00")),
+    ],
 )
 async def test_write_data_items(spec, items, expected_buffer, column_options):
     column = get_column_by_spec(spec, column_options)


### PR DESCRIPTION
In case of empty value the previous row value for column was used because of buffer reuse