### PR TITLE
#20 Attempt to reconnect after ping fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,16 +22,16 @@ deps:
 	@poetry install --no-root
 
 style: deps
-	@isort -src $(checkfiles)
-	@black $(black_opts) $(checkfiles)
+	@poetry run isort -src $(checkfiles)
+	@poetry run black $(black_opts) $(checkfiles)
 
 check: deps
-	@black --check $(black_opts) $(checkfiles) || (echo "Please run 'make style' to auto-fix style issues" && false)
-	@flake8 $(checkfiles)
-	@bandit -x tests -r $(checkfiles) -s B107
+	@poetry run black --check $(black_opts) $(checkfiles) || (echo "Please run 'make style' to auto-fix style issues" && false)
+	@poetry run flake8 $(checkfiles)
+	@poetry run bandit -x tests -r $(checkfiles) -s B107
 
 test: deps
-	$(py_warn) pytest
+	$(py_warn) poetry run pytest
 
 build: deps clean
 	@poetry build

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -571,10 +571,14 @@ class Connection:
     async def force_connect(self):
         if not self.connected:
             await self.connect()
-
-        elif not await self.ping():
-            logger.warning("Connection was closed, reconnecting.")
-            await self.connect()
+        else:
+            try:
+                if not await self.ping():
+                    logger.warning("Connection was closed, reconnecting.")
+                    await self.connect()
+            except:
+                logger.warning("Connection was closed, reconnecting.")
+                await self.connect()
 
     async def process_ordinary_query(
         self,


### PR DESCRIPTION
My naive approach to attempt to fix #20.

When building the local environment, I found that some commands in `Makefile` do not use virtual environment managed by poetry. I have included the changes to make these commands runnable on my local machine, but if it's breaking CI do let me know and I'll remove them in the merge request.

I did not include tests because I do not know if there is a reliable way to produce the "stale" connection in ClickHouse other than opening the connection pool without doing anything for an hour.