### PR TITLE
fix timezone warning

### DIFF
--- a/asynch/proto/columns/datetimecolumn.py
+++ b/asynch/proto/columns/datetimecolumn.py
@@ -196,7 +196,7 @@ def create_datetime_column(spec, column_options):
     else:
         if not context.settings.get("use_client_time_zone", False):
             try:
-                local_timezone = get_localzone().zone
+                local_timezone = str(get_localzone())
             except Exception:
                 local_timezone = None
 


### PR DESCRIPTION
Suppress warning:
```
/Users/user/Library/Caches/pypoetry/virtualenvs/asynch-56aJZi1l-py3.10/lib/python3.10/site-packages/asynch/proto/columns/datetimecolumn.py:199: PytzUsageWarning: The zone attribute is specific to pytz's interface; please migrate to a new time zone provider. For more details on how to do so, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
  local_timezone = get_localzone().zone
```
Getting a time zone’s name
ref: https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html#getting-a-time-zone-s-name