### PR TITLE
Fix processing "PING" messages with unstable networks

### DIFF
--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -255,13 +255,21 @@ class Connection:
                 msg = self.unexpected_packet_message("Pong", packet_type)
                 raise UnexpectedPacketFromServerError(msg)
         except IndexError as e:
-            logger.warning(
+            logger.debug(
                 "Ping package smaller than expected or empty. "
                 "There may be connection or network problems - "
                 "we believe that the connection is incorrect.",
                 exc_info=e,
             )
             return False
+        except (ConnectionError, OSError, RuntimeError) as e:
+            # If raised RuntimeError with "TCPTransport the handler is closed" - just returning false,
+            # because this is a connection loss case
+            if isinstance(e, RuntimeError) and "TCPTransport closed=True" not in str(e):
+                raise
+            logger.debug("Socket closed", exc_info=e)
+            return False
+
         return True
 
     async def receive_data(self):

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -244,15 +244,24 @@ class Connection:
             raise UnexpectedPacketFromServerError(message)
 
     async def ping(self):
-        await self.writer.write_varint(ClientPacket.PING)
-        await self.writer.flush()
-        packet_type = await self.reader.read_varint()
-        while packet_type == ServerPacket.PROGRESS:
-            await self.receive_progress()
+        try:
+            await self.writer.write_varint(ClientPacket.PING)
+            await self.writer.flush()
             packet_type = await self.reader.read_varint()
-        if packet_type != ServerPacket.PONG:
-            msg = self.unexpected_packet_message("Pong", packet_type)
-            raise UnexpectedPacketFromServerError(msg)
+            while packet_type == ServerPacket.PROGRESS:
+                await self.receive_progress()
+                packet_type = await self.reader.read_varint()
+            if packet_type != ServerPacket.PONG:
+                msg = self.unexpected_packet_message("Pong", packet_type)
+                raise UnexpectedPacketFromServerError(msg)
+        except IndexError as e:
+            logger.warning(
+                "Ping package smaller than expected or empty. "
+                "There may be connection or network problems - "
+                "we believe that the connection is incorrect.",
+                exc_info=e,
+            )
+            return False
         return True
 
     async def receive_data(self):

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -266,7 +266,7 @@ class Connection:
             # If raised RuntimeError with "TCPTransport the handler is closed" - just returning false,
             # because this is a connection loss case
             if isinstance(e, RuntimeError) and "TCPTransport closed=True" not in str(e):
-                raise
+                raise e
             logger.debug("Socket closed", exc_info=e)
             return False
 

--- a/tests/test_proto/test_connection.py
+++ b/tests/test_proto/test_connection.py
@@ -1,15 +1,20 @@
 import re
+from unittest.mock import patch
 
 import pytest
 
 from asynch.proto.connection import Connection
 
-conn = Connection()
+
+@pytest.fixture()
+async def conn() -> Connection:
+    _conn = Connection()
+    await _conn.connect()
+    return _conn
 
 
 @pytest.mark.asyncio
-async def test_connect():
-    await conn.connect()
+async def test_connect(conn: Connection):
     assert conn.connected
     assert conn.server_info.name == "ClickHouse"
     assert conn.server_info.timezone == "UTC"
@@ -18,13 +23,54 @@ async def test_connect():
 
 
 @pytest.mark.asyncio
-async def test_ping():
+async def test_ping(conn: Connection):
     await conn.connect()
-    assert await conn.ping()
+    assert await conn.ping() is True
 
 
 @pytest.mark.asyncio
-async def test_execute():
+async def test_ping_processing_with_invalid_package_size(conn: Connection):
+    with patch.object(
+        conn.reader, "_read_one", side_effect=IndexError("Empty bytes array")
+    ) as mock:
+        result = await conn.ping()
+        mock.assert_called_once()
+        assert result is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(ConnectionError("Any connection error"), id="any ConnectionError"),
+        pytest.param(OSError("Any OS error"), id="any OSError"),
+        pytest.param(
+            RuntimeError(
+                "RuntimeError: TCPTransport closed=True: localhost"
+            ),  # Check parsing exc message
+            id="RuntimeError with TCPTransport closed",
+        ),
+    ],
+)
+async def test_ping_catch_connection_error(conn: Connection, exception: Exception):
+    with patch.object(conn.reader, "read_varint", side_effect=exception) as mock:
+        result = await conn.ping()
+        mock.assert_called_once()
+        assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ping_raise_other_runtime_errors(conn: Connection):
+    with patch.object(
+        conn.reader, "read_varint", side_effect=RuntimeError("Any exception")
+    ) as mock:
+        with pytest.raises(RuntimeError, match="Any exception"):
+            await conn.ping()
+        mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_execute(conn: Connection):
     query = "SELECT 1"
     ret = await conn.execute(query)
     assert ret == [(1,)]


### PR DESCRIPTION
This PR attempts to fix the IndexError issues described in #20 and #25. I believe that until the checklist is completed, it should be taken as a draft.

- [x] Tests written
- [x] The fix was tested as part of this [PR](https://github.com/i8enn/asynch/pull/1) on a project with similar issues.

The problem is that in case of problems with the network, the buffer in the `BufferedReader` is empty (equal `bytearray()`) and an attempt to read data at index "0" raises an IndexError exception.

In the case of "PING" messages, we can assume that this behavior is caused by network problems and the current connection is not valid, so we can notify the user about this and return "false".

I understand that this error is caused by code that references [clickhouse-driver](https://github.com/mymarilyn/clickhouse-driver), but there are some differences with the `proto` module code. Unfortunately, I have not yet checked if such an error occurs in clickhouse-driver.