### PR TITLE
Fix a bug in case the SimpleAggregateFunction type has a comma in its definition.

### DIFF
--- a/asynch/proto/columns/simpleaggregatefunctioncolumn.py
+++ b/asynch/proto/columns/simpleaggregatefunctioncolumn.py
@@ -1,5 +1,6 @@
 def create_simple_aggregate_function_column(spec, column_by_spec_getter):
     # SimpleAggregateFunction(Func, Type) -> Type
-    inner = spec[24:-1].split(",")[1].strip()
+    # We allow 1 split, because the nested Type can contain more comma.
+    inner = spec[24:-1].split(",", 1)[1].strip()
     nested = column_by_spec_getter(inner)
     return nested


### PR DESCRIPTION
`SimpleAggregateFunction(something, Tuple(String, String))` would trigger that bug as the `inner` variable would be `Tuple(String`.

This fixes it by splitting only on the first comma that it encounters. I assume there is no comma in the function name.