### PR TITLE
Stop closing connection each time cursor executes query

### DIFF
--- a/asynch/cursors.py
+++ b/asynch/cursors.py
@@ -43,11 +43,7 @@ class Cursor:
         """Does nothing, required by DB API."""
 
     async def close(self):
-        conn = self._connection
-        if conn is None:
-            return
-        await self._connection.close()
-        self._connection = None
+        self._state = self._states.CURSOR_CLOSED
 
     async def execute(
         self,


### PR DESCRIPTION
It's a bug, that Cursor closes connection (it is lower in the "call hierarchy"). It leads to performance decrease.

Closes https://github.com/long2ice/asynch/issues/39