### PR TITLE
Fix pull request #72

### DIFF
--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -289,8 +289,8 @@ class Connection:
         if self.verify:
             ssl_ctx.verify_mode = ssl.VerifyMode.CERT_REQUIRED
         else:
-            ssl_ctx.verify_mode = ssl.VerifyMode.CERT_NONE
             ssl_ctx.check_hostname = False
+            ssl_ctx.verify_mode = ssl.VerifyMode.CERT_NONE
         return ssl_ctx
 
     async def ping(self):


### PR DESCRIPTION
Fix pull request #72

Hostname check must be disabled before setting verify mode to `NONE`, otherwise next exception is raised
```
...
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/base.py", line 66, in __aenter__
  return await self.start(is_ctxmanager=True)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 599, in start
  await self.conn.start(is_ctxmanager=is_ctxmanager)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 157, in start
  await (greenlet_spawn(self.sync_engine.connect))
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 126, in greenlet_spawn
  result = context.throw(*sys.exc_info())
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/future/engine.py", line 406, in connect
  return super(Engine, self).connect()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3325, in connect
  return self._connection_cls(self, close_with_result=close_with_result)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 96, in __init__
  else engine.raw_connection()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3404, in raw_connection
  return self._wrap_pool_connect(self.pool.connect, _connection)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3371, in _wrap_pool_connect
  return fn()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 327, in connect
  return _ConnectionFairy._checkout(self)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 894, in _checkout
  fairy = _ConnectionRecord.checkout(pool)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 493, in checkout
  rec = pool._do_get()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 145, in _do_get
  with util.safe_reraise():
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
  compat.raise_(
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
  raise exception
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 143, in _do_get
  return self._create_connection()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 273, in _create_connection
  return _ConnectionRecord(self)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 388, in __init__
  self.__connect()
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 690, in __connect
  with util.safe_reraise():
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
  compat.raise_(
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/compat.py", line 211, in raise_
  raise exception
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 686, in __connect
  self.dbapi_connection = connection = pool._invoke_creator(self)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 574, in connect
  return dialect.connect(*cargs, **cparams)
File "/usr/local/lib/python3.10/site-packages/clickhouse_sqlalchemy/drivers/base.py", line 443, in connect
  return super(ClickHouseDialect, self).connect(*cargs, **cparams)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 598, in connect
  return self.dbapi.connect(*cargs, **cparams)
File "/usr/local/lib/python3.10/site-packages/clickhouse_sqlalchemy/drivers/asynch/connector.py", line 149, in connect
  await_only(self.asynch.connect(*args, **kwargs))
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 68, in await_only
  return current.driver.switch(awaitable)
File "/usr/local/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 121, in greenlet_spawn
  value = await result
File "/usr/local/lib/python3.10/site-packages/asynch/connection.py", line 203, in connect
  await conn.connect()
File "/usr/local/lib/python3.10/site-packages/asynch/connection.py", line 98, in connect
  await self._connection.connect()
File "/usr/local/lib/python3.10/site-packages/asynch/proto/connection.py", line 571, in connect
  return await self._init_connection(host, port)
File "/usr/local/lib/python3.10/site-packages/asynch/proto/connection.py", line 533, in _init_connection
  reader, writer = await asyncio.open_connection(host, port, ssl=self._get_ssl_context())
File "/usr/local/lib/python3.10/site-packages/asynch/proto/connection.py", line 292, in _get_ssl_context
  ssl_ctx.verify_mode = ssl.VerifyMode.CERT_NONE
File "/usr/local/lib/python3.10/ssl.py", line 738, in verify_mode
  super(SSLContext, SSLContext).verify_mode.__set__(self, value)
ValueError: Cannot set verify_mode to CERT_NONE when check_hostname is enabled.
```
