### PR TITLE
make clickhouse-cityhash dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 > pip install asynch
 ```
 
+or if you want to install [`clickhouse-cityhash`](https://pypi.org/project/clickhouse-cityhash/) to enable
+transport compression
+
+```shell
+> pip install asynch[compression]
+```
+
 ## Usage
 
 Connect to ClickHouse

--- a/asynch/proto/streams/compressed.py
+++ b/asynch/proto/streams/compressed.py
@@ -1,7 +1,5 @@
-from clickhouse_cityhash.cityhash import CityHash128
-
 from asynch.proto import constants
-from asynch.proto.compression import BaseCompressor
+from asynch.proto.compression import BaseCompressor, import_cityhash
 from asynch.proto.context import Context
 from asynch.proto.streams.block import BlockReader, BlockWriter
 from asynch.proto.streams.buffered import (
@@ -28,6 +26,7 @@ class CompressedBlockWriter(BlockWriter):
         super().__init__(reader, self.writer, context)
 
     async def finalize(self):
+        CityHash128 = import_cityhash()
         await self.writer.flush()
 
         compressed = await self.get_compressed()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,15 @@ python = "^3.7"
 leb128 = "*"
 pytz = "*"
 lz4 = "*"
+clickhouse-cityhash = { version = "*", optional = true }
 zstd = "*"
 tzlocal = "*"
 ciso8601 = "*"
 
-[tool.poetry.group.compressoin.dependencies]
-clickhouse-cityhash = "*"
+[tool.poetry.extras]
+compression = ["clickhouse-cityhash"]
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.dev.dependencies]
 flake8 = "*"
 pyproject-flake8 = "*"
 isort = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,12 @@ python = "^3.7"
 leb128 = "*"
 pytz = "*"
 lz4 = "*"
-clickhouse-cityhash = "*"
 zstd = "*"
 tzlocal = "*"
 ciso8601 = "*"
+
+[tool.poetry.group.compressoin.dependencies]
+clickhouse-cityhash = "*"
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
As per https://github.com/xzkostyan/clickhouse-cityhash/pull/3 `clickhouse-cityhash` can't currently be installed on M1 macs, it's also not required in many scenariois.

The solution is to only import it when it needs to be used, and make it an optional dependency.

I've installed this branch locally and it's working fine.

I'm not at all clear on how to correctly implement optional dependencies with poetry, please let me know if something needs changing here.