### PR TITLE
Connection failure leaves connection in an unusable state

### DIFF
--- a/asynch/proto/context.py
+++ b/asynch/proto/context.py
@@ -46,8 +46,12 @@ class ExecuteContext:
         self._connection.make_query_settings(settings)
 
     async def __aenter__(self):
-        await self._connection.force_connect()
-        self._connection.last_query = QueryInfo(self._connection.reader)
+        try:
+            await self._connection.force_connect()
+            self._connection.last_query = QueryInfo(self._connection.reader)
+        except (Exception, KeyboardInterrupt):
+            await self._connection.disconnect()
+            raise
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if exc_type:


### PR DESCRIPTION
When a query eventually made its way into the `ExecuteContext`, if establishing the connection raised an error within the `__aenter__` section, the connection was not being cleared up. Subsequent queries to the same connection (in a pool) would state that the "previous query should be finished first."

In this pull request, we attempt to disconnect the connection (essentially doing the same thing `__aexit__` does), marking it as stale within its associated pool, if the connection fails to be establish.

Thanks to @borgmatthew as well who helped with identifying the issue.