### PR TITLE
Fix broken connections in pool

### DIFF
--- a/asynch/connection.py
+++ b/asynch/connection.py
@@ -80,6 +80,10 @@ class Connection:
     def echo(self):
         return self._echo
 
+    @property
+    def is_query_executing(self) -> bool:
+        return self._connection.is_query_executing
+
     async def close(self):
         if self._is_closed:
             return

--- a/asynch/cursors.py
+++ b/asynch/cursors.py
@@ -279,12 +279,14 @@ class Cursor:
             raise ProgrammingError("no results to fetch")
 
     def _check_query_executing(self):
-        if self._connection._connection.is_query_executing:
-            raise ProgrammingError("records have not fetched, fetch all before execute next")
+        if self._connection.is_query_executing:
+            raise ProgrammingError(
+                "some records have not been fetched. fetch remaining records before executing the next query"
+            )
 
     def _check_cursor_closed(self):
         if self._state == self._states.CURSOR_CLOSED:
-            raise InterfaceError("cursor already closed")
+            raise InterfaceError("cursor is already closed")
 
     def _begin_query(self):
         self._state = self._states.RUNNING

--- a/asynch/proto/context.py
+++ b/asynch/proto/context.py
@@ -46,8 +46,12 @@ class ExecuteContext:
         self._connection.make_query_settings(settings)
 
     async def __aenter__(self):
-        await self._connection.force_connect()
-        self._connection.last_query = QueryInfo(self._connection.reader)
+        try:
+            await self._connection.force_connect()
+            self._connection.last_query = QueryInfo(self._connection.reader)
+        except:  # noqa
+            await self._connection.disconnect()
+            raise
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if exc_type:


### PR DESCRIPTION
Sometimes, the connection can fail on the `connect` stage due to some unexpected error (e.g., network error. Example stack trace: https://pastila.nl/?00413e13/61b1dde4391c8ca6c33e13c77b81d916#C8Y5TPqFSMYzm1jCC7aj7A==). In that case, the connection will be returned to the connection pool in a "broken" state, and all queries with this connection will fail with the `records have not fetched` error.

This PR should fix this problem.