### PR TITLE
Fix a `bytearray index out of range` error while reading a string.

### DIFF
--- a/asynch/proto/streams/buffered.py
+++ b/asynch/proto/streams/buffered.py
@@ -122,11 +122,11 @@ class BufferedReader:
         return packet
 
     async def read_varint(self):
-        if self.position == self.current_buffer_size:
-            self._reset_buffer()
-            await self._read_into_buffer()
         packets = bytearray()
         while True:
+            if self.position == self.current_buffer_size:
+                self._reset_buffer()
+                await self._read_into_buffer()
             packet = self._read_one()
             packets.append(packet)
             if packet < 0x80:


### PR DESCRIPTION
Sometimes, a data chunk we are trying to read from CH can exceed a buffer size. If it happens, the data will be split into two parts. Sometimes it can happen during the `read_varint`, so we must fetch the next buffered chunk before finishing the read.

Closes 
- https://github.com/long2ice/asynch/issues/69
- https://github.com/long2ice/asynch/issues/20