### PR TITLE
reset connection state

### DIFF
--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -144,6 +144,7 @@ class Pool(asyncio.AbstractServer):
             if self._closing:
                 await connection.close()
             else:
+                connection._connection.reset_state()
                 self._free.append(connection)
         fut = self._loop.create_task(self._wakeup())
         return fut

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,4 +1,6 @@
 import pytest
+from socket import gaierror
+from asyncio import gather
 
 from asynch.connection import Connection
 
@@ -30,3 +32,33 @@ async def test_acquire(pool):
     await pool.release(conn)
     assert pool.freesize == 1
     assert pool.size == 1
+
+
+@pytest.mark.asyncio
+async def test_clean_pool_connection_on_error(pool):
+    assert pool
+
+    async def raise_net_error():
+        raise gaierror
+
+    for _ in range(100):
+        async with pool.acquire() as conn:
+            async with conn.cursor() as cursor:
+                try:
+                    # simulate network error while executing the query
+                    await gather(
+                        cursor.execute('SELECT 1'),
+                        raise_net_error()
+                    )
+                except gaierror:
+                    pass
+
+    assert conn._connection.writer is None
+    assert conn._connection.reader is None
+    assert conn._connection.block_reader is None
+    assert conn._connection.block_reader_raw is None
+    assert conn._connection.block_writer is None
+    assert conn._connection.connected is False
+    assert conn._connection.client_trace_context is None
+    assert conn._connection.server_info is None
+    assert conn._connection.is_query_executing is False


### PR DESCRIPTION
When connection was interrupted for some how while executing the query it must be cleaned. Calling `connection._connection.reset_state()` returns connection back to pool cleaned.

The problem was discussed here #93 and #71 