### PR TITLE
Make non-flag `Enum` classes singular 

### DIFF
--- a/asynch/connection.py
+++ b/asynch/connection.py
@@ -5,7 +5,7 @@ from asynch.cursors import Cursor
 from asynch.errors import NotSupportedError
 from asynch.proto import constants
 from asynch.proto.connection import Connection as ProtoConnection
-from asynch.proto.models.enums import ConnectionStatuses
+from asynch.proto.models.enums import ConnectionStatus
 from asynch.proto.utils.dsn import parse_dsn
 
 
@@ -134,15 +134,15 @@ class Connection:
 
         :raise ConnectionError: an unresolved connection state
         :return: the Connection object status
-        :rtype: str (ConnectionStatuses StrEnum)
+        :rtype: str (ConnectionStatus StrEnum)
         """
 
         if self._opened is None and self._closed is None:
-            return ConnectionStatuses.created
+            return ConnectionStatus.created
         if self._opened:
-            return ConnectionStatuses.opened
+            return ConnectionStatus.opened
         if self._closed:
-            return ConnectionStatuses.closed
+            return ConnectionStatus.closed
         raise ConnectionError(f"{self} is in an unknown state")
 
     @property

--- a/asynch/cursors.py
+++ b/asynch/cursors.py
@@ -4,7 +4,7 @@ from typing import Optional
 from warnings import warn
 
 from asynch.errors import InterfaceError, ProgrammingError
-from asynch.proto.models.enums import CursorStatuses
+from asynch.proto.models.enums import CursorStatus
 
 Column = namedtuple("Column", "name type_code display_size internal_size precision scale null_ok")
 
@@ -15,7 +15,7 @@ class States:
     warn(
         (
             "Should not be used in the version 0.2.6 or later."
-            "Should be replaced with the reconsidered `CursorStatuses` enum "
+            "Should be replaced with the reconsidered `CursorStatus` enum "
             "from the `asynch.proto.models.enums` module."
         ),
         DeprecationWarning,
@@ -59,7 +59,7 @@ class Cursor:
         """Return the status of the cursor.
 
         :return: the Cursor object status
-        :rtype: str (CursorStatuses StrEnum)
+        :rtype: str (CursorStatus StrEnum)
         """
 
         return self._state
@@ -71,7 +71,7 @@ class Cursor:
         """Does nothing, required by DB API."""
 
     async def close(self):
-        self._state = CursorStatuses.closed
+        self._state = CursorStatus.closed
 
     async def execute(
         self,
@@ -141,7 +141,7 @@ class Cursor:
         if self._stream_results:
             try:
                 return await self._rows.next()
-            except:  # noqa: E722
+            except Exception:
                 return None
 
         if not self._rows:
@@ -188,7 +188,7 @@ class Cursor:
         Prepares a cursor object to handle another query.
         """
 
-        self._state = CursorStatuses.ready
+        self._state = CursorStatus.ready
 
         self._columns = None
         self._types = None
@@ -281,7 +281,7 @@ class Cursor:
 
     @property
     def description(self):
-        if self._state == CursorStatuses.ready:
+        if self._state == CursorStatus.ready:
             return None
 
         columns = self._columns or []
@@ -293,7 +293,7 @@ class Cursor:
         ]
 
     def _check_query_started(self):
-        if self._state == CursorStatuses.ready:
+        if self._state == CursorStatus.ready:
             raise ProgrammingError(f"no results to fetch from the {self}")
 
     def _check_query_executing(self):
@@ -303,14 +303,14 @@ class Cursor:
             )
 
     def _check_cursor_closed(self):
-        if self._state == CursorStatuses.closed:
+        if self._state == CursorStatus.closed:
             raise InterfaceError(f"the {self} is already closed")
 
     def _begin_query(self):
-        self._state = CursorStatuses.running
+        self._state = CursorStatus.running
 
     def _end_query(self):
-        self._state = CursorStatuses.finished
+        self._state = CursorStatus.finished
 
     def set_stream_results(self, stream_results, max_row_buffer):
         """

--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -9,7 +9,7 @@ from warnings import warn
 from asynch.connection import Connection, connect
 from asynch.errors import ClickHouseException
 from asynch.proto import constants
-from asynch.proto.models.enums import PoolStatuses
+from asynch.proto.models.enums import PoolStatus
 
 logger = logging.getLogger(__name__)
 
@@ -164,15 +164,15 @@ class Pool(asyncio.AbstractServer):
 
         :raise AsynchPoolError: an unresolved pool state.
         :return: the Pool object status
-        :rtype: str (PoolStatuses StrEnum)
+        :rtype: str (PoolStatus StrEnum)
         """
 
         if self._opened is None and self._closed is None:
-            return PoolStatuses.created
+            return PoolStatus.created
         if self._opened:
-            return PoolStatuses.opened
+            return PoolStatus.opened
         if self._closed:
-            return PoolStatuses.closed
+            return PoolStatus.closed
         raise AsynchPoolError(f"{self} is in an unknown state")
 
     @property

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -22,7 +22,7 @@ from asynch.proto.block import (
 from asynch.proto.compression import get_compressor_cls
 from asynch.proto.context import Context, ExecuteContext
 from asynch.proto.cs import ClientInfo, QueryKind, ServerInfo
-from asynch.proto.models.enums import CompressionAlgorithms, Schemes
+from asynch.proto.models.enums import ClickhouseScheme, CompressionAlgorithm
 from asynch.proto.progress import Progress
 from asynch.proto.protocol import ClientPacket, Compression, ServerPacket
 from asynch.proto.result import (
@@ -103,7 +103,7 @@ class Connection:
         self.hosts = [(host, port or default_port)]
         if alt_hosts:
             for host in alt_hosts.split(","):
-                url = urlparse(f"{Schemes.clickhouse}://" + host)
+                url = urlparse(f"{ClickhouseScheme.clickhouse}://" + host)
                 self.hosts.append((url.hostname, url.port or default_port))
         self.database = database
         self.host = None
@@ -129,7 +129,7 @@ class Connection:
         self.ssl_options = ssl_options
         # Use LZ4 compression by default.
         if compression is True:
-            compression = CompressionAlgorithms.lz4
+            compression = CompressionAlgorithm.lz4
 
         if compression is False:
             self.compression = Compression.DISABLED

--- a/asynch/proto/models/enums.py
+++ b/asynch/proto/models/enums.py
@@ -1,31 +1,31 @@
 from enum import Enum
 
 
-class CompressionAlgorithms(str, Enum):
+class CompressionAlgorithm(str, Enum):
     lz4 = "lz4"
     lz4hc = "lz4hc"
     zstd = "zstd"
 
 
-class ConnectionStatuses(str, Enum):
+class ConnectionStatus(str, Enum):
     created = "created"
     opened = "opened"
     closed = "closed"
 
 
-class CursorStatuses(str, Enum):
+class CursorStatus(str, Enum):
     ready = "ready"
     running = "running"
     finished = "finished"
     closed = "closed"
 
 
-class PoolStatuses(str, Enum):
+class PoolStatus(str, Enum):
     created = "created"
     opened = "opened"
     closed = "closed"
 
 
-class Schemes(str, Enum):
+class ClickhouseScheme(str, Enum):
     clickhouse = "clickhouse"
     clickhouses = "clickhouses"

--- a/asynch/proto/utils/dsn.py
+++ b/asynch/proto/utils/dsn.py
@@ -2,17 +2,17 @@ import ssl
 from typing import Any
 from urllib.parse import ParseResult, parse_qs, unquote, urlparse
 
-from asynch.proto.models.enums import CompressionAlgorithms, Schemes
+from asynch.proto.models.enums import ClickhouseScheme, CompressionAlgorithm
 from asynch.proto.utils.compat import asbool
 
 _SCHEME_SEPARATOR = "://"
 
 _COMPRESSION_ALGORITHMS: set[str] = {
-    CompressionAlgorithms.lz4,
-    CompressionAlgorithms.lz4hc,
-    CompressionAlgorithms.zstd,
+    CompressionAlgorithm.lz4,
+    CompressionAlgorithm.lz4hc,
+    CompressionAlgorithm.zstd,
 }
-_SUPPORTED_SCHEMES: set[str] = {Schemes.clickhouse, Schemes.clickhouses}
+_SUPPORTED_SCHEMES: set[str] = {ClickhouseScheme.clickhouse, ClickhouseScheme.clickhouses}
 _TIMEOUTS: set[str] = {"connect_timeout", "send_receive_timeout", "sync_request_timeout"}
 
 
@@ -68,7 +68,7 @@ def parse_dsn(dsn: str) -> dict[str, Any]:
     if path:
         kwargs["database"] = path
 
-    if url.scheme == Schemes.clickhouses:
+    if url.scheme == ClickhouseScheme.clickhouses:
         kwargs["secure"] = True
 
     for name, value in parse_qs(url.query).items():

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -6,7 +6,7 @@ import pytest
 from asynch.connection import Connection
 from asynch.pool import AsynchPoolError, Pool
 from asynch.proto import constants
-from asynch.proto.models.enums import PoolStatuses
+from asynch.proto.models.enums import PoolStatus
 
 
 @pytest.mark.asyncio
@@ -31,7 +31,7 @@ async def test_pool_repr():
     pool = Pool()
     repstr = (
         f"<Pool(minsize={constants.POOL_MIN_SIZE}, maxsize={constants.POOL_MAX_SIZE})"
-        f" object at 0x{id(pool):x}; status: {PoolStatuses.created}>"
+        f" object at 0x{id(pool):x}; status: {PoolStatus.created}>"
     )
     assert repr(pool) == repstr
 
@@ -40,13 +40,13 @@ async def test_pool_repr():
     async with pool:
         repstr = (
             f"<Pool(minsize={min_size}, maxsize={max_size}) "
-            f"object at 0x{id(pool):x}; status: {PoolStatuses.opened}>"
+            f"object at 0x{id(pool):x}; status: {PoolStatus.opened}>"
         )
         assert repr(pool) == repstr
 
     repstr = (
         f"<Pool(minsize={min_size}, maxsize={max_size}) "
-        f"object at 0x{id(pool):x}; status: {PoolStatuses.closed}>"
+        f"object at 0x{id(pool):x}; status: {PoolStatus.closed}>"
     )
     assert repr(pool) == repstr
 

--- a/tests/test_proto/utils/test_dsn.py
+++ b/tests/test_proto/utils/test_dsn.py
@@ -4,7 +4,7 @@ from typing import Any, ContextManager, Optional
 
 import pytest
 
-from asynch.proto.models.enums import CompressionAlgorithms, Schemes
+from asynch.proto.models.enums import ClickhouseScheme, CompressionAlgorithm
 from asynch.proto.utils.dsn import DSNError, parse_dsn
 
 
@@ -13,10 +13,10 @@ from asynch.proto.utils.dsn import DSNError, parse_dsn
     [
         ("", pytest.raises(DSNError), None),
         ("some_scheme://", pytest.raises(DSNError), None),
-        (f"{Schemes.clickhouse}://", pytest.raises(DSNError), None),
-        (f"{Schemes.clickhouses}://", pytest.raises(DSNError), None),
+        (f"{ClickhouseScheme.clickhouse}://", pytest.raises(DSNError), None),
+        (f"{ClickhouseScheme.clickhouses}://", pytest.raises(DSNError), None),
         (
-            f"{Schemes.clickhouse}://ch@lochost/",
+            f"{ClickhouseScheme.clickhouse}://ch@lochost/",
             does_not_raise(),
             {
                 "user": "ch",
@@ -24,7 +24,7 @@ from asynch.proto.utils.dsn import DSNError, parse_dsn
             },
         ),
         (
-            f"{Schemes.clickhouse}://ch:pwd@lochost/",
+            f"{ClickhouseScheme.clickhouse}://ch:pwd@lochost/",
             does_not_raise(),
             {
                 "user": "ch",
@@ -33,7 +33,7 @@ from asynch.proto.utils.dsn import DSNError, parse_dsn
             },
         ),
         (
-            f"{Schemes.clickhouse}://ch@lochost:4321/",
+            f"{ClickhouseScheme.clickhouse}://ch@lochost:4321/",
             does_not_raise(),
             {
                 "user": "ch",
@@ -42,7 +42,7 @@ from asynch.proto.utils.dsn import DSNError, parse_dsn
             },
         ),
         (
-            f"{Schemes.clickhouse}://ch:pwd@lochost:1234/db",
+            f"{ClickhouseScheme.clickhouse}://ch:pwd@lochost:1234/db",
             does_not_raise(),
             {
                 "user": "ch",
@@ -58,12 +58,12 @@ from asynch.proto.utils.dsn import DSNError, parse_dsn
             None,
         ),
         (
-            f"{Schemes.clickhouse}://lochost:1234/test",
+            f"{ClickhouseScheme.clickhouse}://lochost:1234/test",
             does_not_raise(),
             {"host": "lochost", "port": 1234, "database": "test"},
         ),
         (
-            f"{Schemes.clickhouse} :// lochost : 1234 / test",
+            f"{ClickhouseScheme.clickhouse} :// lochost : 1234 / test",
             pytest.raises(DSNError),
             None,
         ),
@@ -82,7 +82,7 @@ def test_dsn_basic_credentials(
     ("dsn", "query", "answer"),
     [
         (
-            f"{Schemes.clickhouses}://ch:pwd@loc:1029/def",
+            f"{ClickhouseScheme.clickhouses}://ch:pwd@loc:1029/def",
             "verify=true&ssl_version=PROTOCOL_TLSv1&ca_certs=path/to/CA.crt&ciphers=AES&client_name",
             {
                 "verify": True,
@@ -92,7 +92,7 @@ def test_dsn_basic_credentials(
             },
         ),
         (
-            f"{Schemes.clickhouse}://ch:pwd@loc:2938/ault",
+            f"{ClickhouseScheme.clickhouse}://ch:pwd@loc:2938/ault",
             (
                 "verify=true"
                 "&secure=yes"
@@ -108,7 +108,7 @@ def test_dsn_basic_credentials(
             {
                 "verify": True,
                 "secure": True,
-                "compression": CompressionAlgorithms.zstd,
+                "compression": CompressionAlgorithm.zstd,
                 "client_name": "my_ch_client",
                 "compress_block_size": 21,
                 "ssl_version": ssl.PROTOCOL_TLSv1,


### PR DESCRIPTION
After some inquiries on enumeration naming guidelines, I realised that it might be a nice idea to have the non bit-field or multiple-flag enumerations singular. the existing enums bear rather mutual exclusive values which cannot be set simultaneously.