### PR TITLE
Add the Pool's available_connections property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.2
 
+### 0.2.6
+
+- Add the `available_connections` property to the `Pool` class. The issue #121 by @itssimon. By @stankudrow in #122
+
 ### 0.2.5
 
 - Add more validation rules in the `parse_dsn` function. By @stankudrow in #113

--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -215,6 +215,20 @@ class Pool(asyncio.AbstractServer):
         return len(self._acquired_connections)
 
     @property
+    def available_connections(self) -> int:
+        """Returns the number of available connections in the pool.
+
+        The number of available connections means
+        those that can be acquired from the pool.
+        Equivalent to `pool.maxsize - pool.connections`.
+
+        :return: the number of connections available to be requested from the pool
+        :rtype: int
+        """
+
+        return self.maxsize - self.connections
+
+    @property
     def free_connections(self) -> int:
         """Returns the number of free connections in the pool.
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -59,24 +59,29 @@ async def test_pool_connection_attributes(config):
     assert pool.connections == 0
     assert pool.free_connections == 0
     assert pool.acquired_connections == 0
+    assert pool.available_connections == constants.POOL_MAX_SIZE
 
     async with pool:
         assert pool.connections == constants.POOL_MIN_SIZE
         assert pool.free_connections == constants.POOL_MIN_SIZE
         assert pool.acquired_connections == 0
+        assert pool.available_connections == (constants.POOL_MAX_SIZE - constants.POOL_MIN_SIZE)
 
         async with pool.connection():
             assert pool.connections == constants.POOL_MIN_SIZE
             assert pool.free_connections == 0
             assert pool.acquired_connections == constants.POOL_MIN_SIZE
+            assert pool.available_connections == (constants.POOL_MAX_SIZE - constants.POOL_MIN_SIZE)
 
         assert pool.connections == constants.POOL_MIN_SIZE
         assert pool.free_connections == constants.POOL_MIN_SIZE
         assert pool.acquired_connections == 0
+        assert pool.available_connections == (constants.POOL_MAX_SIZE - constants.POOL_MIN_SIZE)
 
     assert pool.connections == 0
     assert pool.free_connections == 0
     assert pool.acquired_connections == 0
+    assert pool.available_connections == constants.POOL_MAX_SIZE
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The `pool.available_connections` property shows the number of connections one can request from the pool.

If a pool object is requested to give out a connection when the number of acquired connections is equal to the `pool.maxsize` property, the `AsynchPoolError` is raised because the pool cannot give birth to a connection when its capacities are exceeded.

A possible use case:
```python
async with pool:
    # some code
    if pool.availlable_connections:
        conn_ctx_manager = pool.connection()
       # one can safely request a connection from the pool
    else:
        # requesting a connection from the pool will lead to the AsynchPoolError
```

The source of inspiration: the issue #121 by @itssimon .