### PR TITLE
Improve pool connection handling

### DIFF
--- a/asynch/connection.py
+++ b/asynch/connection.py
@@ -6,9 +6,7 @@ from asynch.proto import constants
 from asynch.proto.connection import Connection as ProtoConnection
 from asynch.proto.models.enums import ConnectionStatus
 from asynch.proto.utils.dsn import parse_dsn
-import logging
 
-logger = logging.getLogger(__name__)
 
 class Connection:
     def __init__(

--- a/asynch/connection.py
+++ b/asynch/connection.py
@@ -6,7 +6,9 @@ from asynch.proto import constants
 from asynch.proto.connection import Connection as ProtoConnection
 from asynch.proto.models.enums import ConnectionStatus
 from asynch.proto.utils.dsn import parse_dsn
+import logging
 
+logger = logging.getLogger(__name__)
 
 class Connection:
     def __init__(
@@ -178,32 +180,25 @@ class Connection:
             msg = f"Ping has failed for {self}"
             raise ConnectionError(msg)
 
-    async def _refresh(self) -> None:
-        """Refresh the connection.
+    async def is_live(self) -> bool:
+        """Checks if the connection is live.
 
-        Attempting to ping and if failed,
-        then trying to connect again.
-        If the reconnection does not work,
-        an Exception is propagated.
+        Attempts to ping and returns True if successful.
 
         :raises ConnectionError:
             1. refreshing created, i.e., not opened connection
             2. refreshing already closed connection
 
-        :return: None
+        :return: True if the connection is alive, otherwise False.
         """
-
-        if self.status == ConnectionStatus.created:
-            msg = f"the {self} is not opened to be refreshed"
-            raise ConnectionError(msg)
-        if self.status == ConnectionStatus.closed:
-            msg = f"the {self} is already closed"
-            raise ConnectionError(msg)
+        if self.status == ConnectionStatus.created or self.status == ConnectionStatus.closed:
+            return False
 
         try:
             await self.ping()
+            return True
         except ConnectionError:
-            await self.connect()
+            return False
 
     async def rollback(self):
         raise NotSupportedError

--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections import deque
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager, suppress
+from contextlib import asynccontextmanager
 from typing import Optional
 
 from asynch.connection import Connection
@@ -170,7 +170,7 @@ class Pool:
             self._acquired_connections.append(conn)
             return conn
 
-        logger.debug(f"No free connection in pool. Creating new connection.")
+        logger.debug("No free connection in pool. Creating new connection.")
         conn = await self._create_connection()
         self._acquired_connections.append(conn)
         return conn

--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -132,7 +132,7 @@ class Pool:
     def minsize(self) -> int:
         return self._minsize
 
-    async def _create_connection(self) -> None:
+    async def _create_connection(self) -> Connection:
         if self._pool_size == self._maxsize:
             raise AsynchPoolError(f"{self} is already full")
         if self._pool_size > self._maxsize:
@@ -143,10 +143,14 @@ class Pool:
 
         try:
             await conn.ping()
-            self._free_connections.append(conn)
+            return conn
         except ConnectionError as e:
             msg = f"failed to create a {conn} for {self}"
             raise AsynchPoolError(msg) from e
+
+    async def _create_and_release_connection(self) -> None:
+        conn = await self._create_connection()
+        self._free_connections.append(conn)
 
     def _pop_connection(self) -> Connection:
         if not self._free_connections:
@@ -166,8 +170,8 @@ class Pool:
             self._acquired_connections.append(conn)
             return conn
 
-        await self._create_connection()
-        conn = self._pop_connection()
+        logger.debug(f"No free connection in pool. Creating new connection.")
+        conn = await self._create_connection()
         self._acquired_connections.append(conn)
         return conn
 
@@ -177,7 +181,7 @@ class Pool:
 
         self._acquired_connections.remove(conn)
         if await conn.is_live():
-            logger.info(f"Releasing connection {conn}")
+            logger.debug(f"Releasing connection {conn}")
             self._free_connections.append(conn)
 
     async def _init_connections(self, n: int, *, strict: bool = False) -> None:
@@ -195,7 +199,7 @@ class Pool:
 
         # it is possible that the `_create_connection` may not create `n` connections
         tasks: list[asyncio.Task] = [
-            asyncio.create_task(self._create_connection()) for _ in range(n)
+            asyncio.create_task(self._create_and_release_connection()) for _ in range(n)
         ]
         # that is why possible exceptions from the `_create_connection` are also gathered
         if strict and any(
@@ -222,12 +226,12 @@ class Pool:
         :return: a free connection from the pool
         :rtype: Connection
         """
-        logger.debug(f"{self._free_connections} free connections, {self._acquired_connections} acquired connections")
+        logger.debug(f"Acquiring connection from Pool ({len(self._free_connections)} free connections, {len(self._acquired_connections)} acquired connections)")
 
         async with self._sem:
             async with self._lock:
                 conn = await self._acquire_connection()
-                logger.debug("acquired connection %s", conn)
+                logger.debug(f"Acquired connection {conn}")
 
             try:
                 yield conn

--- a/asynch/pool.py
+++ b/asynch/pool.py
@@ -226,7 +226,9 @@ class Pool:
         :return: a free connection from the pool
         :rtype: Connection
         """
-        logger.debug(f"Acquiring connection from Pool ({len(self._free_connections)} free connections, {len(self._acquired_connections)} acquired connections)")
+        logger.debug(
+            f"Acquiring connection from Pool ({len(self._free_connections)} free connections, {len(self._acquired_connections)} acquired connections)"
+        )
 
         async with self._sem:
             async with self._lock:

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -578,7 +578,9 @@ class Connection:
         if self.connected:
             await self.disconnect()
         for host, port in self.hosts:
-            logger.debug("Connecting to %s:%s Database: %s. User: %s", host, port, self.database, self.user)
+            logger.debug(
+                "Connecting to %s:%s Database: %s. User: %s", host, port, self.database, self.user
+            )
             return await self._init_connection(host, port)
 
     async def execute(

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -577,9 +577,8 @@ class Connection:
     async def connect(self):
         if self.connected:
             await self.disconnect()
-        logger.debug("Connecting. Database: %s. User: %s", self.database, self.user)
         for host, port in self.hosts:
-            logger.debug("Connecting to %s:%s", host, port)
+            logger.debug("Connecting to %s:%s Database: %s. User: %s", host, port, self.database, self.user)
             return await self._init_connection(host, port)
 
     async def execute(

--- a/asynch/proto/constants.py
+++ b/asynch/proto/constants.py
@@ -1,6 +1,6 @@
 # DSN default values
 DEFAULT_USER = "default"
-DEFAULT_PASSWORD = "default"  # nosec: B105
+DEFAULT_PASSWORD = ""  # nosec: B105
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 9000

--- a/asynch/proto/constants.py
+++ b/asynch/proto/constants.py
@@ -1,6 +1,6 @@
 # DSN default values
 DEFAULT_USER = "default"
-DEFAULT_PASSWORD = ""  # nosec: B105
+DEFAULT_PASSWORD = "default"  # nosec: B105
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 9000

--- a/asynch/proto/streams/buffered.py
+++ b/asynch/proto/streams/buffered.py
@@ -61,6 +61,9 @@ class BufferedWriter:
     async def close(self) -> None:
         if not self.writer:
             return
+        if self.writer.is_closing():
+            return
+
         self.writer.close()
         await self.writer.wait_closed()
 


### PR DESCRIPTION
I think that the current implementation of the connection pool is not ideal, which leads to some subtle problems.

The connection pool always "refreshes" every connection it takes from the pool, and thereby simply reconnects a connection that had been closed. This happens even though there might be another still alive connection in the pool.

Imagine a situation where the pool has two `free_connections`. The first one is closed, the second on still alive. I would expect the connection pool to test all connections until it finds one that works and acquires that connection. This removes closed connections from the pool and avoids additional latency from unnecessarily re-establishing a new connection.

I therefore changed the behaviour of the connection acquisition in the pool. The pool no longer "refreshes" connections, but only checks if the connection is still live (by sending a ping). It does so until it finds a live connection.

(There was actually another bug in the refreshing: Re-connecting the connection never actually worked, because the check for `if self._opened` in `connect()` always returned True, thus exiting the connect method. This only worked because the `ExecutionContext` inside `execute()` finally re-established the connection.)

I also added some debug logs, which helps understanding this behaviour.