### PR TITLE
Ensure param substitution works for c-style formatted queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3
 
+### 0.3.2
+
+- Restore %(param)s style param substition support. By @baconfield in #147
+
 ### 0.3.1
 
 - Fix params substitution for select queries. By @dmkulazhenko in #141.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ async def fetchall():
         assert ret == [(1,)]
 ```
 
+Executing an SQL statement with parameters:
+
+```python
+async def execute(conn: Connection):
+    # by default, an instance of the `Cursor` class
+    async with conn.cursor() as cursor:
+        await cursor.execute(
+            """
+            SELECT
+                EXISTS(
+                    SELECT 1
+                    FROM table_a
+                    WHERE profile_id = %(profile_id)s
+                ) AS has_a,
+                EXISTS(
+                    SELECT 1
+                    FROM table_b
+                    WHERE profile_id = %(profile_id)s
+                ) AS has_b
+            """,
+            {"profile_id": profile_id}
+        )
+        ret = await cursor.fetchone()
+        assert ret == (True,)
+```
+
 Using an instance of the `DictCursor` class to get results as a sequence of `dict`ionaries representing the rows of an executed SQL query:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Executing an SQL statement with parameters:
 
 ```python
 async def execute(conn: Connection):
-    # by default, an instance of the `Cursor` class
     async with conn.cursor() as cursor:
         await cursor.execute(
             """

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -36,7 +36,7 @@ from asynch.proto.settings import write_settings
 from asynch.proto.streams.block import BlockReader, BlockWriter
 from asynch.proto.streams.buffered import BufferedReader, BufferedWriter
 from asynch.proto.utils.escape import escape_params
-from asynch.proto.utils.helpers import chunks, column_chunks
+from asynch.proto.utils.helpers import chunks, column_chunks, query_is_format_style
 
 logger = logging.getLogger(__name__)
 
@@ -806,7 +806,9 @@ class Connection:
         if not isinstance(params, Mapping):
             raise ValueError("Parameters are expected to be a mapping")
 
-        return query.format(**escape_params(params))
+        if query_is_format_style(query):
+            return query.format(**escape_params(params))
+        return query % escape_params(params)
 
     async def process_insert_query(
         self,

--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -36,7 +36,7 @@ from asynch.proto.settings import write_settings
 from asynch.proto.streams.block import BlockReader, BlockWriter
 from asynch.proto.streams.buffered import BufferedReader, BufferedWriter
 from asynch.proto.utils.escape import escape_params
-from asynch.proto.utils.helpers import chunks, column_chunks, query_is_format_style
+from asynch.proto.utils.helpers import chunks, column_chunks
 
 logger = logging.getLogger(__name__)
 
@@ -806,8 +806,6 @@ class Connection:
         if not isinstance(params, Mapping):
             raise ValueError("Parameters are expected to be a mapping")
 
-        if query_is_format_style(query):
-            return query.format(**escape_params(params))
         return query % escape_params(params)
 
     async def process_insert_query(

--- a/asynch/proto/utils/helpers.py
+++ b/asynch/proto/utils/helpers.py
@@ -1,4 +1,5 @@
 from itertools import islice, tee
+from string import Formatter
 
 
 def chunks(seq, n):
@@ -29,3 +30,8 @@ def pairwise(iterable):
     a, b = tee(iterable)
     next(b, None)
     return zip(a, b)
+
+
+def query_is_format_style(query: str) -> bool:
+    """Validate that query uses {name} style formatting"""
+    return any(name for _, name, *_ in Formatter().parse(query) if name)

--- a/asynch/proto/utils/helpers.py
+++ b/asynch/proto/utils/helpers.py
@@ -1,5 +1,4 @@
 from itertools import islice, tee
-from string import Formatter
 
 
 def chunks(seq, n):
@@ -30,8 +29,3 @@ def pairwise(iterable):
     a, b = tee(iterable)
     next(b, None)
     return zip(a, b)
-
-
-def query_is_format_style(query: str) -> bool:
-    """Validate that query uses {name} style formatting"""
-    return any(name for _, name, *_ in Formatter().parse(query) if name)

--- a/tests/test_proto/test_proto_connection.py
+++ b/tests/test_proto/test_proto_connection.py
@@ -97,10 +97,45 @@ async def test_execute_with_args(proto_conn: ProtoConnection):
 
 
 @pytest.mark.asyncio
+async def test_execute_with_args_and_no_placeholder(proto_conn: ProtoConnection):
+    query = "SELECT 1"
+    ret = await proto_conn.execute(query, args={"val": 2})
+    assert ret == [(1,)]
+
+
+@pytest.mark.asyncio
 async def test_execute_with_missing_arg(proto_conn: ProtoConnection):
     query = "SELECT {var}"
     with pytest.raises(KeyError, match="'var'"):
         await proto_conn.execute(query, args={"foo": 1})
+
+
+@pytest.mark.asyncio
+async def test_execute_with_multiple_args(proto_conn: ProtoConnection):
+    query = "SELECT {val}, {var}"
+    ret = await proto_conn.execute(query, args={"val": 2, "var": 3})
+    assert ret == [(2, 3)]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_c_format_args(proto_conn: ProtoConnection):
+    query = "SELECT %(val)s"
+    ret = await proto_conn.execute(query, args={"val": 2})
+    assert ret == [(2,)]
+
+
+@pytest.mark.asyncio
+async def test_execute_with_missing_c_format_arg(proto_conn: ProtoConnection):
+    query = "SELECT %(var)s"
+    with pytest.raises(KeyError, match="'var'"):
+        await proto_conn.execute(query, args={"foo": 1})
+
+
+@pytest.mark.asyncio
+async def test_execute_with_multiple_c_format_args(proto_conn: ProtoConnection):
+    query = "SELECT %(val)s, %(var)s"
+    ret = await proto_conn.execute(query, args={"val": 2, "var": 3})
+    assert ret == [(2, 3)]
 
 
 @asynccontextmanager

--- a/tests/test_proto/test_proto_connection.py
+++ b/tests/test_proto/test_proto_connection.py
@@ -90,13 +90,6 @@ async def test_execute(proto_conn: ProtoConnection):
 
 
 @pytest.mark.asyncio
-async def test_execute_with_args(proto_conn: ProtoConnection):
-    query = "SELECT {val}"
-    ret = await proto_conn.execute(query, args={"val": 2})
-    assert ret == [(2,)]
-
-
-@pytest.mark.asyncio
 async def test_execute_with_args_and_no_placeholder(proto_conn: ProtoConnection):
     query = "SELECT 1"
     ret = await proto_conn.execute(query, args={"val": 2})
@@ -104,35 +97,21 @@ async def test_execute_with_args_and_no_placeholder(proto_conn: ProtoConnection)
 
 
 @pytest.mark.asyncio
-async def test_execute_with_missing_arg(proto_conn: ProtoConnection):
-    query = "SELECT {var}"
-    with pytest.raises(KeyError, match="'var'"):
-        await proto_conn.execute(query, args={"foo": 1})
-
-
-@pytest.mark.asyncio
-async def test_execute_with_multiple_args(proto_conn: ProtoConnection):
-    query = "SELECT {val}, {var}"
-    ret = await proto_conn.execute(query, args={"val": 2, "var": 3})
-    assert ret == [(2, 3)]
-
-
-@pytest.mark.asyncio
-async def test_execute_with_c_format_args(proto_conn: ProtoConnection):
+async def test_execute_with_args(proto_conn: ProtoConnection):
     query = "SELECT %(val)s"
     ret = await proto_conn.execute(query, args={"val": 2})
     assert ret == [(2,)]
 
 
 @pytest.mark.asyncio
-async def test_execute_with_missing_c_format_arg(proto_conn: ProtoConnection):
+async def test_execute_with_missing_arg(proto_conn: ProtoConnection):
     query = "SELECT %(var)s"
     with pytest.raises(KeyError, match="'var'"):
         await proto_conn.execute(query, args={"foo": 1})
 
 
 @pytest.mark.asyncio
-async def test_execute_with_multiple_c_format_args(proto_conn: ProtoConnection):
+async def test_execute_with_multiple_args(proto_conn: ProtoConnection):
     query = "SELECT %(val)s, %(var)s"
     ret = await proto_conn.execute(query, args={"val": 2, "var": 3})
     assert ret == [(2, 3)]


### PR DESCRIPTION
Fixing param substitution for `%(name)s` formatting, e.g. cases like:
```python
await self.cursor.execute(
    """
    SELECT
        EXISTS(
            SELECT 1
            FROM table_a
            WHERE profile_id = %(profile_id)s
        ) AS has_a,
        EXISTS(
            SELECT 1
            FROM table_b
            WHERE profile_id = %(profile_id)s
        ) AS has_b
    """,
    {"profile_id": profile_id}
)
```

https://github.com/long2ice/asynch/pull/141#issuecomment-3522308952