### PR TITLE
Prevent disconnect on server exception

### DIFF
--- a/asynch/proto/connection.py
+++ b/asynch/proto/connection.py
@@ -442,6 +442,7 @@ class Connection:
 
         elif packet_type == ServerPacket.EXCEPTION:
             packet.exception = await self.receive_exception()
+            self.is_query_executing = False
 
         elif packet.type == ServerPacket.PROGRESS:
             packet.progress = await self.receive_progress()

--- a/asynch/proto/context.py
+++ b/asynch/proto/context.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional
 
+from asynch.errors import ServerException
 from asynch.proto.result import QueryInfo
 
 if TYPE_CHECKING:
@@ -55,7 +56,9 @@ class ExecuteContext:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if exc_type:
-            if issubclass(exc_type, (Exception, KeyboardInterrupt)):
+            if not issubclass(exc_type, ServerException) and issubclass(
+                exc_type, (Exception, KeyboardInterrupt)
+            ):
                 await self._connection.disconnect()
                 raise exc_val
         self._connection.track_current_database(self._query)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,6 @@
 import pytest
 
+from asynch import Connection
 from asynch.errors import ServerException
 from asynch.pool import Pool
 
@@ -11,3 +12,16 @@ async def test_database_exists(config):
             async with conn.cursor() as cursor:
                 with pytest.raises(ServerException):
                     await cursor.execute("create database test")
+
+
+@pytest.mark.asyncio
+async def test_connection_does_not_close_after_exception():
+    async with Connection() as conn:
+        async with conn.cursor() as cur:
+            with pytest.raises(ServerException):
+                await cur.execute("foo")
+
+            assert conn._connection.connected is True
+            assert conn.opened is True
+
+            await cur.execute("select 1")


### PR DESCRIPTION
When the server sends an exception, we don't need to close the connection, but can continue to use it. This fixes the bug that is mentioned in https://github.com/long2ice/asynch/issues/93#issuecomment-3062311987 