### PR TITLE
Fix compression for inserts

### DIFF
--- a/asynch/proto/streams/buffered.py
+++ b/asynch/proto/streams/buffered.py
@@ -219,6 +219,7 @@ class CompressedBufferedWriter(BufferedWriter):
     async def flush(self):
         await self.compressor.write(self.buffer)
         self.position = 0
+        self.buffer = bytearray()
 
 
 class CompressedBufferedReader(BufferedReader):

--- a/tests/test_proto/test_proto_connection.py
+++ b/tests/test_proto/test_proto_connection.py
@@ -10,14 +10,15 @@ from asynch.proto.connection import Connection as ProtoConnection
 from asynch.proto.cs import ServerInfo
 
 
-@pytest.fixture()
-async def proto_conn(config) -> AsyncIterator[ProtoConnection]:
+@pytest.fixture(params=[False, "lz4", "zstd"])
+async def proto_conn(request, config) -> AsyncIterator[ProtoConnection]:
     _conn = ProtoConnection(
         user=config.user,
         password=config.password,
         host=config.host,
         port=config.port,
         database=config.database,
+        compression=request.param,
     )
     await _conn.connect()
     yield _conn
@@ -101,6 +102,17 @@ async def test_execute_with_missing_arg(proto_conn: ProtoConnection):
     query = "SELECT {var}"
     with pytest.raises(KeyError, match="'var'"):
         await proto_conn.execute(query, args={"foo": 1})
+
+
+@pytest.mark.asyncio
+async def test_large_insert(proto_conn: ProtoConnection):
+    data = [(1,)] * 10_000
+    async with create_table(proto_conn, "a Int64"):
+        await proto_conn.execute(
+            "INSERT INTO test.test (a) VALUES", data, settings={"insert_block_size": 1000}
+        )
+        rv = await proto_conn.execute("SELECT * FROM test.test")
+        assert rv == data
 
 
 @asynccontextmanager


### PR DESCRIPTION
Compression was broken for inserts because of a bug in the CompressedStreamWriter. fixes https://github.com/long2ice/asynch/issues/149