### PR TITLE
fix: handle empty offsets in MapColumn.read_items

### DIFF
--- a/asynch/proto/columns/mapcolumn.py
+++ b/asynch/proto/columns/mapcolumn.py
@@ -27,6 +27,9 @@ class MapColumn(Column):
         await self.value_column.write_state_prefix()
 
     async def read_items(self, n_items):
+        if not n_items:
+            return [{}]
+
         offsets = list(await self.offset_column.read_items(n_items))
         last_offset = offsets[-1]
         keys = await self.key_column.read_data(last_offset)

--- a/tests/test_proto/columns/test_mapcolumn.py
+++ b/tests/test_proto/columns/test_mapcolumn.py
@@ -69,6 +69,16 @@ async def create_table(cursor: Cursor, spec: str):
             ],
             None,
         ],
+        [
+            "a Map(String, Map(String, Int32))",
+            [
+                ({},),
+                ({"key1": {}},),
+                ({"key1": {"nested": 1}},),
+                ({"key1": {"a": 1, "b": 2}, "key2": {"c": 3}},),
+            ],
+            None,
+        ],
     ],
     ids=[
         "simple",
@@ -76,6 +86,7 @@ async def create_table(cursor: Cursor, spec: str):
         "low_cardinally",
         "array",
         "decimal",
+        "nested_map",
     ],
 )
 async def test_map_column(


### PR DESCRIPTION
## Summary
When reading Map columns with zero items (e.g., an empty nested Map), the offsets list is empty, causing an `IndexError` when accessing `offsets[-1]`.

## Root Cause
In `mapcolumn.py`, `read_items` does not handle the case when `n_items` is 0:

```python
async def read_items(self, n_items):
    offsets = list(await self.offset_column.read_items(n_items))
    last_offset = offsets[-1]  # <-- crashes when offsets is empty
    ...
```

## Fix
This PR adds an early return when `n_items` is 0, matching the approach used in clickhouse-driver [commit c123f2c](https://github.com/mymarilyn/clickhouse-driver/commit/c123f2cfdc96bc4e2e5d5ac81adb2c5370deb819) which was released in version 0.2.8.

```python
async def read_items(self, n_items):
    if not n_items:
        return [{}]
    offsets = list(await self.offset_column.read_items(n_items))
    ...
```

## Testing
Added a test case for nested Map columns that includes empty maps.

Fixes #154
