### PR TITLE
fix: Science python 3.13 `getpass.getuser` raise OSError instead KeyError

### DIFF
--- a/asynch/proto/cs.py
+++ b/asynch/proto/cs.py
@@ -66,7 +66,7 @@ class ClientInfo:
 
         try:
             self.os_user = getpass.getuser()
-        except KeyError:
+        except (KeyError, OSError):
             self.os_user = ""
         self.client_hostname = socket.gethostname()
         self.client_name = client_name


### PR DESCRIPTION
### Summary
Since python 3.13 raising exception type in getpass.getuser has been changed. 